### PR TITLE
added a basic html survey

### DIFF
--- a/survey.html
+++ b/survey.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>DCVOAD Member Form</title>
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
+  <script src="https://code.jquery.com/jquery.js"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js"></script>
+
+</head>
+<body>
+
+
+  <h1>DCVOAD</h1>
+
+  <h3>Please add your organization's information:</h3>
+
+  <div class="row">
+      <div class="col-lg-12">
+        <div class="panel panel-default">
+          <div class="panel-heading">
+            <h3 class="panel-title"><strong>Public Information</strong></h3>
+          </div>
+          <div class="panel-body">
+            <form role="form">
+
+              <div class="form-group">
+                <label for="name">Organization Name</label>
+                <input type="text" class="form-control" id="orgName">
+              </div>
+
+              <div class="form-group">
+                <label for="role">Organization Website</label>
+                <input type="text" class="form-control" id="orgWebsite">
+              </div>
+
+              <div class="form-group">
+                <label for="age">Public Contact Phone Number</label>
+                <input type="text" class="form-control" id="orgNumber">
+              </div>
+
+              <div class="form-group">
+                <label for="force-points">Public Contact Email Address</label>
+                <input type="text" class="form-control" id="orgEmail">
+              </div>
+
+              <div class="form-group">
+                <label for="role">Blurb about Organization (1000 characters or less)</label>
+                <input type="text" class="form-control" id="orgWebsite">
+              </div>
+
+              <div class="form-group">
+                <label for="role">I consent to have the above information listed on the DCVOAD website</label><br>
+                <input type="radio" name="siteConsent" value="true"> Yes <br>
+                <input type="radio" name="siteConsent" value="false" checked> No <br>
+              </div>
+
+            </form>
+            <br>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+            <div class="row">
+                <div class="col-lg-12">
+                  <div class="panel panel-default">
+                    <div class="panel-heading">
+                      <h3 class="panel-title"><strong>Restricted Information</strong></h3>
+                    </div>
+                    <div class="panel-body">
+                      <form role="form">
+
+                        <div class="form-group">
+                          <label for="name">Meeting Planning Point of Contact Name</label>
+                          <input type="text" class="form-control" id="pocName">
+                        </div>
+
+                        <div class="form-group">
+                          <label for="force-points">Meeting Planning Email Address</label>
+                          <input type="text" class="form-control" id="pocEmail">
+                        </div>
+
+                        <div class="form-group">
+                          <label for="force-points">Organization Address</label>
+                          <input type="text" class="form-control" id="orgAddress">
+                        </div>
+
+                        <div class="form-group">
+                          <label for="name">Emergency Point of Contact Name</label>
+                          <input type="text" class="form-control" id="emergPocName">
+                        </div>
+
+                        <div class="form-group">
+                          <label for="age">Emergency Contact Phone Number 1</label>
+                          <input type="text" class="form-control" id="emergPocNumber1">
+                        </div>
+
+                        <div class="form-group">
+                          <label for="age">Emergency Contact Phone Number 2</label>
+                          <input type="text" class="form-control" id="emergPocNumber2">
+                        </div>
+
+                        <div class="form-group">
+                          <label for="force-points">Emergency Contact Email Address</label>
+                          <input type="text" class="form-control" id="emergPocEmail">
+                        </div>
+
+                        <div class="form-group">
+                          <label for="role">This point of contacts consents to be contacted during official disaster response exercises</label><br>
+                          <input type="radio" name="siteConsent" value="true"> Yes <br>
+                          <input type="radio" name="siteConsent" value="false" checked> No <br>
+                        </div>
+
+
+                      </form>
+                      <br>
+
+
+
+
+            <div class="text-right">
+              <button type="submit" class="btn btn-primary btn-md" id="add-btn"><span class="glyphicon glyphicon-fire"></span> Add information to DCVOAD's records</button>
+            </div>
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+  <script type="text/javascript">
+    $("#add-btn").on("click", function(event) {
+      event.preventDefault();
+
+      var newMember = {
+        name: $("#orgName").val().trim(),
+        site: $("#orgWebsite").val().trim(),
+        number: $("#orgNumber").val().trim(),
+        email: $("#orgEmail").val().trim(),
+        blurb: $("#orgBlurb").val().trim(),
+        siteConsent: $("#siteConsent").val().trim(),
+        pocName: $("#pocName").val().trim(),
+        pocEmail: $("#pocEmail").val().trim(),
+        address: $("#orgAddress").val().trim(),
+        emergPocName: $("#emergPocName").val().trim(),
+        emergPocEmail: $("#emergPocEmail").val().trim(),
+        emergPocNumber1: $("#emergPocNumber1").val().trim(),
+        emergPocNumber2: $("#emergPocNumber2").val().trim(),
+        contactConsent: $("#orgEmail").val().trim(),
+      };
+
+
+
+
+    $.post("/api/new", newCharacter)
+      .done(function(data) {
+        console.log(data);
+        alert("Adding character...");
+      });
+
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
There's some javascript borrowed from an old project. I can clean html of all bootstrap extras if we'd prefer a different library or fully custom CSS. We can discuss on Slack or at meeting tomorrow - final decision should be Jon's.

I already noticed an error, line #152 should be #contactConsent, not #orgEmail. We can use this as practice for flagging errors to be corrected on a pull request.